### PR TITLE
People and Companies API created

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem 'slim-rails'
 gem "jsbundling-rails"
 gem 'kaminari'
+gem 'active_model_serializers'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.15)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.0.8.6)
       activesupport (= 7.0.8.6)
       globalid (>= 0.3.6)
@@ -68,6 +73,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    airborne (0.0.18)
+      rest-client (~> 1.7, >= 1.7.2)
+      rspec (~> 3.1, >= 3.1.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
@@ -83,6 +91,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
@@ -94,6 +104,7 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     docile (1.4.1)
+    domain_name (0.6.20240107)
     erubi (1.13.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
@@ -104,6 +115,8 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -115,6 +128,7 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
+    jsonapi-renderer (0.2.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -139,6 +153,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (2.99.3)
     mini_mime (1.1.5)
     minitest (5.25.2)
     net-imap (0.5.1)
@@ -150,6 +165,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
@@ -208,7 +224,15 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rexml (3.3.9)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -299,6 +323,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
+  airborne
   annotate
   capybara
   cssbundling-rails

--- a/app/controllers/api/companies_controller.rb
+++ b/app/controllers/api/companies_controller.rb
@@ -1,0 +1,23 @@
+class Api::CompaniesController < ActionController::API
+  def index
+    if params[:name].present?
+      companies = Company.where('LOWER(name) LIKE ?', "%#{params[:name]&.downcase}%").page(params[:page] || 1).per(params[:per_page] || 10)
+    else
+      companies = Company.all.page(params[:page] || 1).per(10)
+    end
+
+    render json: { meta: pagination_meta(companies), data: companies }, status: 200
+  end
+
+  private
+
+  def pagination_meta(scope)
+    {
+      current_page: scope.current_page,
+      next_page: scope.next_page,
+      prev_page: scope.prev_page,
+      total_pages: scope.total_pages,
+      total_count: scope.total_count
+    }
+  end
+end

--- a/app/controllers/api/people_controller.rb
+++ b/app/controllers/api/people_controller.rb
@@ -1,0 +1,23 @@
+class Api::PeopleController < ActionController::API
+  def index
+    if params[:email].present?
+      people = Person.where(email: params[:email]).page(params[:page] || 1).per(params[:per_page] || 10)
+    else
+      people = Person.includes(:company).page(params[:page] || 1).per(10)
+    end
+
+    render json: { meta: pagination_meta(people), data: people }, status: 200
+  end
+
+  private
+
+  def pagination_meta(scope)
+    {
+      current_page: scope.current_page,
+      next_page: scope.next_page,
+      prev_page: scope.prev_page,
+      total_pages: scope.total_pages,
+      total_count: scope.total_count
+    }
+  end
+end

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -1,0 +1,8 @@
+# app/serializers/person_serializer.rb
+class PersonSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email, :phone_number, :company_name
+
+  def company_name
+    object.company&.name
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,9 @@ Rails.application.routes.draw do
   resources :people, only: [:index, :new, :create]
   resources :companies
   root to: 'people#index'
+
+  namespace :api do
+    resources :people, only: :index
+    resources :companies, only: :index
+  end
 end

--- a/spec/controllers/api/companies_controller_spec.rb
+++ b/spec/controllers/api/companies_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Api::CompaniesController, type: :controller do
+  describe 'GET /api/companies' do
+    let!(:companies) { create_list(:company, 25) }
+
+    it 'returns a successful response' do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns paginated results' do
+      get :index, params: { page: 1, per_page: 10 }
+      json = JSON.parse(response.body)
+      expect(json['meta']['current_page']).to eq(1)
+      expect(json['meta']['total_pages']).to eq(3)
+      expect(json['data'].size).to eq(10)
+    end
+
+    it 'returns filtered results by name' do
+      create(:company, name: 'Acme Corp')
+      get :index, params: { name: 'acme' }
+      json = JSON.parse(response.body)
+      expect(json['data'].size).to eq(1)
+      expect(json['data'][0]['name']).to eq('Acme Corp')
+    end
+
+    it 'handles case-insensitive filtering' do
+      create(:company, name: 'TestCompany')
+      get :index, params: { name: 'testcompany' }
+      json = JSON.parse(response.body)
+      expect(json['data'].size).to eq(1)
+      expect(json['data'][0]['name']).to eq('TestCompany')
+    end
+
+    it 'returns an empty array if no companies match the filter' do
+      get :index, params: { name: 'nonexistent' }
+      json = JSON.parse(response.body)
+      expect(json['data'].size).to eq(0)
+    end
+  end
+end

--- a/spec/controllers/api/people_controller_spec.rb
+++ b/spec/controllers/api/people_controller_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Api::PeopleController, type: :controller do
+  describe 'GET /api/people' do
+    let!(:people) { create_list(:person, 25) }
+
+    it 'returns a successful response' do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns paginated results' do
+      get :index, params: { page: 1, per_page: 10 }
+      json = JSON.parse(response.body)
+      expect(json['meta']['current_page']).to eq(1)
+      expect(json['meta']['total_pages']).to eq(3)
+      expect(json['data'].size).to eq(10)
+    end
+
+    it 'returns filtered results by email' do
+      create(:person, email: 'test@example.com')
+      get :index, params: { email: 'test@example.com' }
+      json = JSON.parse(response.body)
+      expect(json['data'].size).to eq(1)
+      expect(json['data'][0]['email']).to eq('test@example.com')
+    end
+
+    it 'returns an empty array if no people match the email filter' do
+      get :index, params: { email: 'nonexistent@example.com' }
+      json = JSON.parse(response.body)
+      expect(json['data'].size).to eq(0)
+    end
+  end
+end

--- a/spec/controllers/companies_controller.spec.rb
+++ b/spec/controllers/companies_controller.spec.rb
@@ -1,101 +1,102 @@
 require 'rails_helper'
 
 RSpec.describe CompaniesController, type: :controller do
-  let!(:company) { FactoryBot.create(:company, name: "Test Company") }
+  let(:valid_attributes) { { name: 'Test Company' } }
+  let(:invalid_attributes) { { name: '' } }
+  let!(:company) { create(:company, name: 'Existing Company') }
 
-  describe "GET #index" do
-    it "assigns @companies with paginated results" do
+  describe 'GET #index' do
+    it 'assigns @companies with paginated results' do
       get :index, params: { page: 1 }
-      expect(assigns(:companies)).to be_a_kind_of(ActiveRecord::Relation)
-      expect(assigns(:companies)).to include(company)
+      expect(assigns(:companies)).to eq([company])
     end
 
-    it "renders the index template" do
+    it 'renders the index template' do
       get :index
       expect(response).to render_template(:index)
     end
   end
 
-  describe "GET #new" do
-    it "assigns a new Company to @company" do
+  describe 'GET #new' do
+    it 'assigns a new company to @company' do
       get :new
       expect(assigns(:company)).to be_a_new(Company)
     end
 
-    it "renders the new template" do
+    it 'renders the new template' do
       get :new
       expect(response).to render_template(:new)
     end
   end
 
-  describe "GET #edit" do
-    it "assigns the requested company to @company" do
+  describe 'GET #edit' do
+    it 'assigns the requested company to @company' do
       get :edit, params: { id: company.id }
       expect(assigns(:company)).to eq(company)
     end
 
-    it "renders the edit template" do
+    it 'renders the edit template' do
       get :edit, params: { id: company.id }
       expect(response).to render_template(:edit)
     end
   end
 
-  describe "POST #create" do
-    context "with valid attributes" do
-      it "creates a new company" do
+  describe 'POST #create' do
+    context 'with valid attributes' do
+      it 'creates a new company' do
         expect {
-          post :create, params: { company: { name: "New Company" } }
+          post :create, params: { company: valid_attributes }
         }.to change(Company, :count).by(1)
       end
 
-      it "redirects to the index with a success notice" do
-        post :create, params: { company: { name: "New Company" } }
+      it 'redirects to the index with a success notice' do
+        post :create, params: { company: valid_attributes }
         expect(response).to redirect_to(companies_path)
-        expect(flash[:notice]).to eq("Successfully created entry")
+        expect(flash[:notice]).to eq('Successfully created entry')
       end
     end
 
-    context "with invalid attributes" do
-      it "does not create a new company" do
+    context 'with invalid attributes' do
+      it 'does not create a new company' do
         expect {
-          post :create, params: { company: { name: "" } }
+          post :create, params: { company: invalid_attributes }
         }.not_to change(Company, :count)
       end
 
-      it "renders the create template with an alert" do
-        post :create, params: { company: { name: "" } }
+      it 'renders the create template with an alert' do
+        post :create, params: { company: invalid_attributes }
         expect(response).to render_template(:create)
-        expect(flash[:alert]).to eq("Unsuccessfully created entry")
+        expect(flash[:alert]).to eq('Unsuccessfully created entry')
       end
     end
   end
 
-  describe "PATCH #update" do
-    context "with valid attributes" do
-      it "updates the company" do
-        patch :update, params: { id: company.id, company: { name: "Updated Company" } }
+  describe 'PATCH #update' do
+    context 'with valid attributes' do
+      it 'updates the company' do
+        patch :update, params: { id: company.id, company: valid_attributes }
         company.reload
-        expect(company.name).to eq("Updated Company")
+        expect(company.name).to eq('Test Company')
       end
 
-      it "redirects to the index with a success notice" do
-        patch :update, params: { id: company.id, company: { name: "Updated Company" } }
+      it 'redirects to the index with a success notice' do
+        patch :update, params: { id: company.id, company: valid_attributes }
         expect(response).to redirect_to(companies_path)
-        expect(flash[:notice]).to eq("Successfully updated entry")
+        expect(flash[:notice]).to eq('Successfully updated entry')
       end
     end
 
-    context "with invalid attributes" do
-      it "does not update the company" do
-        patch :update, params: { id: company.id, company: { name: "" } }
+    context 'with invalid attributes' do
+      it 'does not update the company' do
+        patch :update, params: { id: company.id, company: invalid_attributes }
         company.reload
-        expect(company.name).to eq("Test Company")
+        expect(company.name).not_to eq('')
       end
 
-      it "renders the edit template with an alert" do
-        patch :update, params: { id: company.id, company: { name: "" } }
+      it 'renders the edit template with an alert' do
+        patch :update, params: { id: company.id, company: invalid_attributes }
         expect(response).to render_template(:edit)
-        expect(flash[:alert]).to eq("Unsuccessfully created entry")
+        expect(flash[:alert]).to eq('Unsuccessfully created entry')
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+
 SimpleCov.start
 
 require 'spec_helper'


### PR DESCRIPTION
## Description
Create an API endpoint that exposes People to the public with filtering based on email, and pagination. Example GET request: { email: 'foo@bar.baz', page: 1, per_page: 10 }

Create an API endpoint that exposes Companies to the public with filtering based on case insensitive partial matches to company name with pagination. Example GET request: { name: 'digital', page: 1, per_page: 10 }

### Endpoints
Companies: /api/companies?name=group
People: /api/people?email=group

## Demo
![image](https://github.com/user-attachments/assets/1c1c9dce-10a8-4600-842a-d0388f985bde)
